### PR TITLE
fix: preserve user-set tmux pane titles

### DIFF
--- a/terminal/tmux/tmux.conf.local
+++ b/terminal/tmux/tmux.conf.local
@@ -226,8 +226,8 @@ set -g status-justify left
 
 # pane title display (tmux 3.3+)
 set -g pane-border-status top
-set -g pane-border-format " #{pane_index}: #{pane_title} "
-bind T command-prompt -p "Pane title:" "select-pane -T '%%'"
+set -g pane-border-format " #{pane_index}: #{?@custom_title,#{@custom_title},#{pane_title}} "
+bind T command-prompt -p "Pane title:" "set-option -p @custom_title '%%'"
 
 # pane navigation (without -r for immediate response)
 bind h select-pane -L


### PR DESCRIPTION
## Summary
- Use a custom pane option (`@custom_title`) to store user-set pane titles separately from application-controlled `#{pane_title}`
- When a user sets a title via `prefix + T`, it persists even when apps (e.g., Claude Code) update the terminal title via escape sequences
- Falls back to dynamic `#{pane_title}` when no custom title is set (empty string or never set)

## Test plan
- [ ] `prefix + r` to reload tmux config
- [ ] Verify pane border shows dynamic title by default
- [ ] `prefix + T` to set a custom title → verify it sticks
- [ ] Run Claude Code in the pane → verify custom title is NOT overwritten
- [ ] `prefix + T` + empty enter → verify fallback to dynamic title

🤖 Generated with [Claude Code](https://claude.com/claude-code)