### PR TITLE
fix: add iTerm2 true color override for tmux

### DIFF
--- a/terminal/tmux/tmux.conf.local
+++ b/terminal/tmux/tmux.conf.local
@@ -217,6 +217,7 @@ set -as terminal-features 'xterm*:extkeys'
 bind -n S-Enter send-keys Escape '[13;2u'
 set -g default-terminal "tmux-256color"
 set -ga terminal-overrides ",*256col*:Tc"
+set -ga terminal-overrides ",iTerm2*:Tc"
 
 # general
 set -g mouse on


### PR DESCRIPTION
## Summary
- Add `iTerm2*:Tc` terminal-override so tmux enables true color when iTerm2 reports its terminal type as `iTerm2*` instead of `xterm-256color`
- Without this, hex colors like `#ffb86c` (gold) may render as wrong colors (e.g., green)

## Test plan
- [ ] Open tmux in iTerm2
- [ ] Verify tmux-power gold theme renders correctly
- [ ] Verify pane borders show correct colors in new windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)