### PR TITLE
feat: add gemini config to dotfiles and improve Claude permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(git checkout:*)",
+      "Bash(git mv:*)",
+      "Bash(git -C:*)",
+      "Bash(gh:*)",
+      "Bash(brew info:*)",
+      "Bash(brew list:*)",
+      "Bash(chmod:*)",
+      "Bash(plutil:*)",
+      "Bash(defaults read:*)",
+      "Skill(commit-commands:commit)",
+      "WebSearch"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Claude Code
 CLAUDE.md
-.claude
+.claude/*
+!.claude/settings.json
 
 # Logs
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,14 @@
 # Claude Code
 CLAUDE.md
-.claude/*
+# .claude/*
 !.claude/settings.json
 
 # Logs
 *.log
 firebase-debug.log
+
+# Secrets
+.env*
 
 # OS
 .DS_Store

--- a/init.sh
+++ b/init.sh
@@ -243,6 +243,9 @@ create_symlinks() {
     mkdir -p "$CONFIG/mise"
     create_symlink "$DOTFILES/tools/mise/config.toml" "$CONFIG/mise/config.toml" "mise config"
 
+    # Gemini
+    create_symlink "$DOTFILES/tools/gemini" "$CONFIG/gemini" "gemini"
+
     # Karabiner
     create_symlink "$DOTFILES/macos/karabiner" "$CONFIG/karabiner" "karabiner"
 

--- a/tools/claude/settings.json
+++ b/tools/claude/settings.json
@@ -1,5 +1,16 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "deny": [
+      "Read(~/.ssh/**)",
+      "Edit(~/.ssh/**)",
+      "Read(~/.gnupg/**)",
+      "Edit(~/.gnupg/**)",
+      "Read(~/.aws/**)",
+      "Edit(~/.aws/**)",
+      "Read(~/.config/gh/hosts.yml)"
+    ]
+  },
   "hooks": {
     "Stop": [
       {

--- a/tools/claude/settings.json
+++ b/tools/claude/settings.json
@@ -1,7 +1,13 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
+    "allow": [
+      "Read(*)",
+      "Bash(cat *)"
+    ],
     "deny": [
+      "Read(**/.env*)",
+      "Bash(cat **/.env*)",
       "Read(~/.ssh/**)",
       "Edit(~/.ssh/**)",
       "Read(~/.gnupg/**)",

--- a/tools/claude/statusline-command.sh
+++ b/tools/claude/statusline-command.sh
@@ -1,23 +1,18 @@
 #!/bin/bash
-# Claude Code Statusline with API Quota
-# Shows: user@host:dir (branch) [model | 5h:X% 7d:Y%]
+# Claude Code Statusline with Firebase/gcloud env check and API Quota
+# Shows: 🔥 firebase-project ☁️ gcloud-project 👤 user@email.com [Model | quota]
 
 # Read input from stdin
 input=$(cat)
-
-# Debug: Save input to file
-echo "$input" >/tmp/statusline-debug.json
 
 # Extract basic info
 current_dir="$(echo "$input" | jq -r '.workspace.current_dir // .cwd')"
 model="$(echo "$input" | jq -r '.model.display_name')"
 
 # Get git branch
-git_branch="$(cd "$current_dir" 2>/dev/null && git branch --show-current 2>/dev/null || echo '')"
+git_branch="$(cd "$current_dir" 2>/dev/null && git -c gc.auto=0 branch --show-current 2>/dev/null || echo '')"
 
 # Build prompt parts
-username="$(whoami)"
-hostname="$(hostname -s)"
 dir_name="$(basename "$current_dir")"
 
 if [ -n "$git_branch" ]; then
@@ -26,15 +21,30 @@ else
 	git_info=""
 fi
 
-# Firebase 환경 확인 (.firebaserc를 현재 및 하위 디렉토리에서 찾기)
+# Firebase 로그인 이메일 확인 (캐시: 5분)
+FIREBASE_CACHE="/tmp/claude-firebase-login-cache"
+FIREBASE_CACHE_MAX_AGE=300
+
+firebase_email=""
+if [ -f "$FIREBASE_CACHE" ]; then
+	cache_age=$(($(date +%s) - $(stat -f %m "$FIREBASE_CACHE" 2>/dev/null || echo 0)))
+	if [ "$cache_age" -lt "$FIREBASE_CACHE_MAX_AGE" ]; then
+		firebase_email=$(cat "$FIREBASE_CACHE")
+	fi
+fi
+
+if [ -z "$firebase_email" ]; then
+	firebase_email=$(firebase login:list 2>/dev/null | grep -o '[^ ]*@[^ ]*' | head -1)
+	echo "${firebase_email:--}" >"$FIREBASE_CACHE"
+fi
+
+# Firebase 프로젝트 확인 (.firebaserc를 현재 및 하위 디렉토리에서 찾기)
 firebase_dir=""
 search_dir="$current_dir"
 
-# 현재 디렉토리에 .firebaserc 있는지 확인
 if [ -f "${search_dir}/.firebaserc" ]; then
 	firebase_dir="$search_dir"
 else
-	# 하위 디렉토리에서 .firebaserc 찾기 (depth 1)
 	for subdir in "$search_dir"/*/; do
 		if [ -f "${subdir}.firebaserc" ]; then
 			firebase_dir="${subdir%/}"
@@ -44,25 +54,39 @@ else
 fi
 
 if [ -n "$firebase_dir" ]; then
-	firebase_env=$(cd "$firebase_dir" 2>/dev/null && firebase use 2>/dev/null | head -1)
-	[ -z "$firebase_env" ] && firebase_env="-"
+	firebase_project=$(cd "$firebase_dir" 2>/dev/null && firebase use 2>/dev/null | head -1)
+	[ -z "$firebase_project" ] && firebase_project="-"
 else
-	firebase_env="-"
+	firebase_project="-"
 fi
 
-# gcloud 환경 확인
-gcloud_env=$(gcloud config get-value project 2>/dev/null)
-[ -z "$gcloud_env" ] && gcloud_env="?"
+# gcloud 프로젝트 확인
+gcloud_project=$(gcloud config get-value project 2>/dev/null)
+[ -z "$gcloud_project" ] && gcloud_project="?"
 
-# gcloud account
-gcloud_account=$(gcloud config get-value account 2>/dev/null | cut -d'@' -f1)
+# Firebase 로그인 표시
+if [ -z "$firebase_email" ] || [ "$firebase_email" = "-" ]; then
+	firebase_info=" ⚠️ Firebase:로그인필요"
+else
+	firebase_info=" 🔥 ${firebase_project}"
+fi
 
-# 환경 표시
-firebase_info=" 🔥 ${firebase_env}"
+# gcloud 프로젝트 표시 (production 경고: f06c6 포함 시)
+if [ "$gcloud_project" = "?" ]; then
+	gcloud_info=" ⚠️ gcloud:미설정"
+elif echo "$gcloud_project" | grep -q "f06c6"; then
+	gcloud_info=" ⚠️ PROD:${gcloud_project}"
+else
+	gcloud_info=" ☁️  ${gcloud_project}"
+fi
 
-gcloud_info=" ☁️  ${gcloud_env}"
-
-account_info=" 👤 ${gcloud_account}"
+# 계정 표시 (gcloud account 또는 firebase email)
+if [ -n "$firebase_email" ] && [ "$firebase_email" != "-" ]; then
+	account_info=" 👤 ${firebase_email}"
+else
+	gcloud_account=$(gcloud config get-value account 2>/dev/null)
+	account_info=" 👤 ${gcloud_account:-?}"
+fi
 
 # Function to get API quota from Anthropic OAuth API
 get_api_quota() {
@@ -159,5 +183,5 @@ else
 fi
 
 # Output statusline
-printf "%s@%s:%s%s%s%s%s [%s]" \
-	"$username" "$hostname" "$dir_name" "$git_info" "$firebase_info" "$gcloud_info" "$account_info" "$status_info"
+printf "%s:%s%s%s%s%s [%s]" \
+	"$dir_name" "" "$git_info" "$firebase_info" "$gcloud_info" "$account_info" "$status_info"

--- a/tools/gemini/summarize.py
+++ b/tools/gemini/summarize.py
@@ -1,0 +1,48 @@
+"""YouTube video summarizer using Gemini API."""
+
+import argparse
+import os
+import sys
+
+from dotenv import load_dotenv
+from google import genai
+from google.genai import types
+
+load_dotenv(os.path.expanduser("~/.config/gemini/.env"))
+
+
+def summarize(url: str, prompt: str | None = None) -> str:
+    api_key = os.environ.get("GEMINI_API_KEY")
+    if not api_key:
+        print("Error: GEMINI_API_KEY not set in ~/.config/gemini/.env", file=sys.stderr)
+        sys.exit(1)
+
+    client = genai.Client(api_key=api_key)
+
+    default_prompt = (
+        "이 영상을 한국어로 요약해줘. "
+        "핵심 내용을 구조화해서 정리하고, "
+        "중요한 기술적 세부사항이 있으면 포함해줘."
+    )
+
+    response = client.models.generate_content(
+        model="gemini-2.5-flash",
+        contents=types.Content(
+            parts=[
+                types.Part(
+                    file_data=types.FileData(file_uri=url)
+                ),
+                types.Part(text=prompt or default_prompt),
+            ]
+        ),
+    )
+    return response.text
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Summarize a YouTube video using Gemini")
+    parser.add_argument("url", help="YouTube video URL")
+    parser.add_argument("-p", "--prompt", help="Custom prompt (default: Korean summary)")
+    args = parser.parse_args()
+
+    print(summarize(args.url, args.prompt))


### PR DESCRIPTION
## Summary
- Add `~/.config/gemini` symlink management via `init.sh` (summarize.py tracked, .env excluded)
- Add `Read(*)` and `Bash(cat *)` to Claude Code allow permissions with `.env*` deny rules
- Add `.env*` to global `.gitignore` for secret protection
- Improve Claude statusline: Firebase login cache, production project warnings, cleaner output format

## Test plan
- [ ] Run `./init.sh` and verify `~/.config/gemini` → `~/.dotfiles/tools/gemini` symlink
- [ ] Verify `.env` file is not tracked by git (`git check-ignore tools/gemini/.env`)
- [ ] Verify Claude Code auto-allows `Read` and `Bash(cat)` but blocks `.env*` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)