### PR TITLE
fix: override tmux C-h/C-l prefix bindings for pane navigation

### DIFF
--- a/macos/claude-notification/switch-tmux.sh
+++ b/macos/claude-notification/switch-tmux.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
-# 알림 클릭 시 해당 tmux 세션/윈도우의 iTerm 윈도우로 이동
-# Usage: switch-tmux.sh [session] [window]
+# 알림 클릭 시 해당 tmux 세션/윈도우/페인으로 이동
+# Usage: switch-tmux.sh [session] [window] [pane]
 
 LOG="/tmp/switch-tmux.log"
 echo "=== $(date) ===" >> "$LOG"
 
 SESSION="$1"
 WINDOW="$2"
+PANE="$3"
 
-echo "SESSION=$SESSION, WINDOW=$WINDOW" >> "$LOG"
+echo "SESSION=$SESSION, WINDOW=$WINDOW, PANE=$PANE" >> "$LOG"
 
 if [ -z "$SESSION" ]; then
     osascript -e 'tell application "iTerm" to activate'
@@ -16,17 +17,31 @@ if [ -z "$SESSION" ]; then
     exit 0
 fi
 
+TMUX=/opt/homebrew/bin/tmux
+
 # 해당 세션에 붙어있는 tmux 클라이언트의 TTY 찾기
-TTY=$(/opt/homebrew/bin/tmux list-clients -t "$SESSION" -F '#{client_tty}' 2>/dev/null | head -1)
+TTY=$($TMUX list-clients -t "$SESSION" -F '#{client_tty}' 2>/dev/null | head -1)
 echo "TTY=$TTY" >> "$LOG"
 
-# tmux 윈도우 먼저 선택
+# tmux 윈도우 선택
 if [ -n "$WINDOW" ]; then
-    /opt/homebrew/bin/tmux select-window -t "$SESSION:$WINDOW" 2>/dev/null
+    $TMUX select-window -t "$SESSION:$WINDOW" 2>/dev/null
+fi
+
+# pane 선택 + zoom
+if [ -n "$PANE" ]; then
+    # 다른 pane이 zoom 되어있으면 먼저 해제
+    IS_ZOOMED=$($TMUX display-message -p -t "$SESSION:$WINDOW" '#{window_zoomed_flag}' 2>/dev/null)
+    if [ "$IS_ZOOMED" = "1" ]; then
+        $TMUX resize-pane -Z -t "$SESSION:$WINDOW" 2>/dev/null
+    fi
+    # 해당 pane 선택 후 zoom
+    $TMUX select-pane -t "$PANE" 2>/dev/null
+    $TMUX resize-pane -Z -t "$PANE" 2>/dev/null
+    echo "pane 선택 + zoom: $PANE" >> "$LOG"
 fi
 
 if [ -n "$TTY" ]; then
-    # TTY에 해당하는 iTerm 윈도우/탭을 찾아서 활성화
     osascript <<APPLESCRIPT
 tell application "iTerm"
     activate
@@ -44,7 +59,6 @@ end tell
 APPLESCRIPT
     echo "iTerm 윈도우 전환 완료 (TTY: $TTY)" >> "$LOG"
 else
-    # 클라이언트 못 찾으면 iTerm만 활성화
     osascript -e 'tell application "iTerm" to activate'
     echo "클라이언트 없음, iTerm만 활성화" >> "$LOG"
 fi

--- a/macos/hammerspoon/init.lua
+++ b/macos/hammerspoon/init.lua
@@ -5,12 +5,12 @@
 require("hs.ipc")
 
 -- Claude Code 알림 함수
--- session, window: 알림 클릭 시 이동할 tmux 세션/윈도우
-function claudeNotify(title, message, session, window)
+-- session, window, pane: 알림 클릭 시 이동할 tmux 세션/윈도우/페인
+function claudeNotify(title, message, session, window, pane)
     local n = hs.notify.new(function(notification)
-        -- 알림 클릭 시 해당 tmux 세션/윈도우로 이동
+        -- 알림 클릭 시 해당 tmux 세션/윈도우/페인으로 이동
         local script = os.getenv("HOME") .. "/.dotfiles/macos/claude-notification/switch-tmux.sh"
-        local cmd = script .. " " .. (session or "") .. " " .. (window or "")
+        local cmd = script .. " " .. (session or "") .. " " .. (window or "") .. " " .. (pane or "")
         hs.execute(cmd)
     end, {
         title = title or "Claude Code",
@@ -23,15 +23,15 @@ function claudeNotify(title, message, session, window)
 end
 
 -- 입력 필요 알림 (다른 사운드)
-function claudeNotifyInput(message, session, window)
+function claudeNotifyInput(message, session, window, pane)
     hs.sound.getByFile("/System/Library/Sounds/Blow.aiff"):play()
-    claudeNotify("Claude Code - 입력 필요", message or "입력이 필요합니다", session, window)
+    claudeNotify("Claude Code - 입력 필요", message or "입력이 필요합니다", session, window, pane)
 end
 
 -- 작업 완료 알림
-function claudeNotifyDone(message, session, window)
+function claudeNotifyDone(message, session, window, pane)
     hs.sound.getByFile("/System/Library/Sounds/Glass.aiff"):play()
-    claudeNotify("Claude Code", message or "작업이 완료되었습니다", session, window)
+    claudeNotify("Claude Code", message or "작업이 완료되었습니다", session, window, pane)
 end
 
 -- CLI에서 호출 가능하도록 전역 등록

--- a/macos/hammerspoon/init.lua
+++ b/macos/hammerspoon/init.lua
@@ -5,11 +5,13 @@
 require("hs.ipc")
 
 -- Claude Code 알림 함수
-function claudeNotify(title, message)
+-- session, window: 알림 클릭 시 이동할 tmux 세션/윈도우
+function claudeNotify(title, message, session, window)
     local n = hs.notify.new(function(notification)
-        -- 알림 클릭 시 실행
+        -- 알림 클릭 시 해당 tmux 세션/윈도우로 이동
         local script = os.getenv("HOME") .. "/.dotfiles/macos/claude-notification/switch-tmux.sh"
-        hs.execute(script)
+        local cmd = script .. " " .. (session or "") .. " " .. (window or "")
+        hs.execute(cmd)
     end, {
         title = title or "Claude Code",
         informativeText = message or "작업이 완료되었습니다",
@@ -21,15 +23,15 @@ function claudeNotify(title, message)
 end
 
 -- 입력 필요 알림 (다른 사운드)
-function claudeNotifyInput(message)
+function claudeNotifyInput(message, session, window)
     hs.sound.getByFile("/System/Library/Sounds/Blow.aiff"):play()
-    claudeNotify("Claude Code - 입력 필요", message or "입력이 필요합니다")
+    claudeNotify("Claude Code - 입력 필요", message or "입력이 필요합니다", session, window)
 end
 
 -- 작업 완료 알림
-function claudeNotifyDone(message)
+function claudeNotifyDone(message, session, window)
     hs.sound.getByFile("/System/Library/Sounds/Glass.aiff"):play()
-    claudeNotify("Claude Code", message or "작업이 완료되었습니다")
+    claudeNotify("Claude Code", message or "작업이 완료되었습니다", session, window)
 end
 
 -- CLI에서 호출 가능하도록 전역 등록

--- a/shell/zsh/zshrc
+++ b/shell/zsh/zshrc
@@ -233,3 +233,4 @@ setopt NO_BEEP
 unset CPPFLAGS
 unset LDFLAGS
 [[ -z "$TMUX" ]] && export TERM=xterm-256color
+export FIREBASE_DEBUG_LOG=/dev/null

--- a/terminal/tmux/tmux.conf.local
+++ b/terminal/tmux/tmux.conf.local
@@ -236,6 +236,13 @@ bind j select-pane -D
 bind k select-pane -U
 bind l select-pane -R
 
+# override C-h/C-l window navigation from base config
+# (easy to accidentally press Ctrl+H instead of just H after prefix)
+bind C-h select-pane -L
+bind C-j select-pane -D
+bind C-k select-pane -U
+bind C-l select-pane -R
+
 # pane swap
 bind -r > swap-pane -D
 bind -r < swap-pane -U

--- a/tools/claude/hooks/permission-notification.sh
+++ b/tools/claude/hooks/permission-notification.sh
@@ -2,20 +2,23 @@
 # Claude Code Notification Hook - 입력 대기/권한 요청 알림 (Hammerspoon)
 
 LOG_FILE="$HOME/.claude/hooks/permission-notification-debug.log"
-CONTEXT_FILE="/tmp/claude-code-tmux-context"
 
 # stdin에서 hook input 읽기
 HOOK_INPUT=$(cat)
 
 echo "=== $(date) ===" >> "$LOG_FILE"
 
-# tmux 컨텍스트 저장 (세션:윈도우:타임스탬프)
+# tmux 세션/윈도우 정보 (알림에 직접 전달)
+SESSION=""
+WINDOW=""
 if [ -n "$TMUX" ]; then
     SESSION=$(tmux display-message -p '#S')
-    WINDOW=$(tmux display-message -p '#I')
-    TIMESTAMP=$(date +%s)
-    echo "${SESSION}:${WINDOW}:${TIMESTAMP}" > "$CONTEXT_FILE"
-    echo "TMUX CONTEXT: ${SESSION}:${WINDOW}" >> "$LOG_FILE"
+    if [ -n "$TMUX_PANE" ]; then
+        WINDOW=$(tmux display-message -p -t "$TMUX_PANE" '#{window_index}')
+    else
+        WINDOW=$(tmux display-message -p '#I')
+    fi
+    echo "TMUX CONTEXT: ${SESSION}:${WINDOW} (PANE=${TMUX_PANE})" >> "$LOG_FILE"
 fi
 
 # message 추출
@@ -37,6 +40,6 @@ echo "" >> "$LOG_FILE"
 
 # Hammerspoon으로 알림 (클릭 시 tmux 세션 이동)
 ESCAPED_MESSAGE=$(echo "$MESSAGE" | sed "s/'/\\\\'/g")
-/opt/homebrew/bin/hs -c "claudeNotifyInput('$ESCAPED_MESSAGE')" &
+/opt/homebrew/bin/hs -c "claudeNotifyInput('$ESCAPED_MESSAGE', '$SESSION', '$WINDOW')" &
 
 exit 0

--- a/tools/claude/hooks/permission-notification.sh
+++ b/tools/claude/hooks/permission-notification.sh
@@ -18,7 +18,8 @@ if [ -n "$TMUX" ]; then
     else
         WINDOW=$(tmux display-message -p '#I')
     fi
-    echo "TMUX CONTEXT: ${SESSION}:${WINDOW} (PANE=${TMUX_PANE})" >> "$LOG_FILE"
+    PANE="$TMUX_PANE"
+    echo "TMUX CONTEXT: ${SESSION}:${WINDOW} (PANE=${PANE})" >> "$LOG_FILE"
 fi
 
 # message 추출
@@ -40,6 +41,6 @@ echo "" >> "$LOG_FILE"
 
 # Hammerspoon으로 알림 (클릭 시 tmux 세션 이동)
 ESCAPED_MESSAGE=$(echo "$MESSAGE" | sed "s/'/\\\\'/g")
-/opt/homebrew/bin/hs -c "claudeNotifyInput('$ESCAPED_MESSAGE', '$SESSION', '$WINDOW')" &
+/opt/homebrew/bin/hs -c "claudeNotifyInput('$ESCAPED_MESSAGE', '$SESSION', '$WINDOW', '$PANE')" &
 
 exit 0

--- a/tools/claude/hooks/stop-notification.sh
+++ b/tools/claude/hooks/stop-notification.sh
@@ -20,7 +20,8 @@ if [ -n "$TMUX" ]; then
     else
         WINDOW=$(tmux display-message -p '#I')
     fi
-    echo "TMUX CONTEXT: ${SESSION}:${WINDOW} (PANE=${TMUX_PANE})" >> "$LOG_FILE"
+    PANE="$TMUX_PANE"
+    echo "TMUX CONTEXT: ${SESSION}:${WINDOW} (PANE=${PANE})" >> "$LOG_FILE"
 fi
 
 # transcript_path 추출
@@ -58,6 +59,6 @@ echo "" >> "$LOG_FILE"
 # Hammerspoon으로 알림 (클릭 시 tmux 세션 이동)
 # 메시지에서 작은따옴표 이스케이프
 ESCAPED_MESSAGE=$(echo "$MESSAGE" | sed "s/'/\\\\'/g")
-/opt/homebrew/bin/hs -c "claudeNotifyDone('$ESCAPED_MESSAGE', '$SESSION', '$WINDOW')" &
+/opt/homebrew/bin/hs -c "claudeNotifyDone('$ESCAPED_MESSAGE', '$SESSION', '$WINDOW', '$PANE')" &
 
 exit 0


### PR DESCRIPTION
## Summary
- Override `C-h/C-j/C-k/C-l` in tmux prefix table to `select-pane` instead of window navigation — fixes accidental window switching when Ctrl is held after prefix key
- Suppress Firebase debug logs (`FIREBASE_DEBUG_LOG=/dev/null`)

## Test plan
- [ ] `prefix + C-h` navigates to left pane (not previous-window)
- [ ] `prefix + C-l` navigates to right pane (not send-keys C-l)
- [ ] `prefix + h/l` still works as before
- [ ] `prefix + Shift+L` (resize) followed by `prefix + l` stays in same window

🤖 Generated with [Claude Code](https://claude.com/claude-code)