### PR TITLE
feat: add tmux-continuum, copy-mode newline strip, and resurrect cleanup

### DIFF
--- a/terminal/tmux/scripts/resurrect-cleanup.sh
+++ b/terminal/tmux/scripts/resurrect-cleanup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Keep only the latest N resurrect save files
+KEEP=30
+RESURRECT_DIR="${HOME}/.local/share/tmux/resurrect"
+
+ls -1t "${RESURRECT_DIR}"/tmux_resurrect_*.txt 2>/dev/null \
+  | tail -n +$((KEEP + 1)) \
+  | while read -r f; do rm -f "$f"; done

--- a/terminal/tmux/tmux.conf.local
+++ b/terminal/tmux/tmux.conf.local
@@ -193,6 +193,7 @@ set -g @plugin 'wfxr/tmux-power'
 set -g @plugin 'tmux-plugins/tmux-prefix-highlight'
 set -g @plugin 'wfxr/tmux-net-speed'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
+set -g @plugin 'tmux-plugins/tmux-continuum'
 set -g @plugin 'christoomey/vim-tmux-navigator'
 set -g @plugin 'schasse/tmux-jump'
 
@@ -203,6 +204,13 @@ set -g @tmux_power_show_upload_speed true
 set -g @tmux_power_show_download_speed true
 set -g @tmux_power_time_icon '🕘'
 set -g @tmux_power_prefix_highlight_pos 'L'
+
+# tmux-resurrect
+set -g @resurrect-hook-post-save-all '~/.dotfiles/terminal/tmux/scripts/resurrect-cleanup.sh'
+
+# tmux-continuum
+set -g @continuum-restore 'on'
+set -g @continuum-save-interval '15'
 
 
 # -- Custom Settings ----------------------------------------------------------
@@ -274,6 +282,9 @@ bind s choose-tree -s -O name
 
 # fast reload (.local only)
 bind r source-file ~/.tmux.conf.local \; display "Reloaded!"
+
+# copy-mode: strip trailing newline when copying to clipboard
+bind -T copy-mode-vi y send -X copy-pipe-and-cancel "perl -pe 'chomp if eof' | pbcopy"
 
 # disable C-l clear (conflicts with vim-tmux-navigator)
 bind -n C-l run 'true'


### PR DESCRIPTION
## Summary
- Add `tmux-continuum` plugin for automatic session save every 15 minutes and auto-restore on tmux start
- Strip trailing newline when copying lines in `copy-mode-vi` with `y` key (pipes through `perl -pe 'chomp if eof' | pbcopy`)
- Add resurrect save file rotation script (`scripts/resurrect-cleanup.sh`) keeping only the latest 30 files, triggered via `@resurrect-hook-post-save-all`

## Test plan
- [ ] `prefix + r` to reload tmux config
- [ ] Verify `tmux show-option -gv @continuum-save-interval` returns `15`
- [ ] Enter copy mode (`prefix + [`), select a line, press `y`, paste and confirm no trailing newline
- [ ] Wait for auto-save and verify old files are cleaned up in `~/.local/share/tmux/resurrect/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)