### PR TITLE
feat: auto-restore Claude Code sessions via tmux-resurrect

### DIFF
--- a/terminal/tmux/scripts/resurrect-claude-resume.sh
+++ b/terminal/tmux/scripts/resurrect-claude-resume.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# tmux-resurrect post-save hook: rewrite claude pane commands in the latest
+# save file to `claude --resume <session-id>` so restored panes reattach to
+# their conversations. Session ids are tagged on panes as @claude_session_id
+# by the Claude Code SessionStart hook (~/.claude/hooks/session-env.sh).
+set -euo pipefail
+
+RESURRECT_DIR="${RESURRECT_DIR:-$HOME/.local/share/tmux/resurrect}"
+SAVE_FILE=$(readlink -f "${RESURRECT_DIR}/last" 2>/dev/null) || exit 0
+[ -f "$SAVE_FILE" ] || exit 0
+
+TAB=$'\t'
+TAGS=$(tmux list-panes -a -F "#{session_name}${TAB}#{window_index}${TAB}#{pane_index}${TAB}#{@claude_session_id}")
+
+# tags go in as a first input file — BSD awk rejects newlines in -v strings
+awk -F '\t' -v OFS='\t' '
+NR == FNR {
+  if (NF >= 4 && $4 != "") tag[$1 SUBSEP $2 SUBSEP $3] = $4
+  next
+}
+# pane line fields: pane, session, win_idx, win_active, :flags, pane_idx,
+#                   title, :cwd, pane_active, current_cmd, :full_cmd
+$1 == "pane" {
+  cmd = substr($NF, 2)
+  id = tag[$2 SUBSEP $3 SUBSEP $6]
+  if (id != "" && cmd ~ /(^|\/)claude( |$)/) {
+    gsub(/ --resume[ =][^ ]+/, "", cmd)  # drop stale session refs
+    gsub(/ --continue/, "", cmd)
+    sub(/ +$/, "", cmd)
+    $NF = ":" cmd " --resume " id
+  }
+}
+{ print }
+' <(printf '%s\n' "$TAGS") "$SAVE_FILE" > "${SAVE_FILE}.tmp" && mv "${SAVE_FILE}.tmp" "$SAVE_FILE"

--- a/terminal/tmux/tmux.conf.local
+++ b/terminal/tmux/tmux.conf.local
@@ -206,7 +206,10 @@ set -g @tmux_power_time_icon '🕘'
 set -g @tmux_power_prefix_highlight_pos 'L'
 
 # tmux-resurrect
-set -g @resurrect-hook-post-save-all '~/.dotfiles/terminal/tmux/scripts/resurrect-cleanup.sh'
+# "~claude" adds claude to the default restore whitelist; saved full command
+# (incl. --resume <id> injected by resurrect-claude-resume.sh) is re-run on restore
+set -g @resurrect-processes '"~claude"'
+set -g @resurrect-hook-post-save-all '~/.dotfiles/terminal/tmux/scripts/resurrect-cleanup.sh; ~/.dotfiles/terminal/tmux/scripts/resurrect-claude-resume.sh'
 
 # tmux-continuum
 set -g @continuum-restore 'on'

--- a/tools/claude/hooks/session-env.sh
+++ b/tools/claude/hooks/session-env.sh
@@ -6,6 +6,16 @@
 LOG_FILE="$HOME/.claude/hooks/session-env.log"
 echo "[$(date)] Hook started, CLAUDE_ENV_FILE=$CLAUDE_ENV_FILE" >> "$LOG_FILE"
 
+# tmux-resurrect integration: tag this pane with the Claude session id so
+# resurrect-claude-resume.sh can rewrite saved commands to `claude --resume <id>`
+if [ -n "$TMUX_PANE" ]; then
+  command -v jq >/dev/null || PATH="/opt/homebrew/bin:$PATH"
+  SESSION_ID=$(jq -r '.session_id // empty' 2>/dev/null)
+  if [ -n "$SESSION_ID" ]; then
+    tmux set-option -pt "$TMUX_PANE" @claude_session_id "$SESSION_ID" 2>/dev/null
+  fi
+fi
+
 if [ -n "$CLAUDE_ENV_FILE" ]; then
   # direnv export로 환경변수 가져오기
   direnv export bash 2>/dev/null | grep '^export ' >> "$CLAUDE_ENV_FILE"


### PR DESCRIPTION
## Summary
- Claude Code SessionStart hook (`tools/claude/hooks/session-env.sh`) tags each tmux pane with its session id as the `@claude_session_id` pane option
- New tmux-resurrect post-save hook (`terminal/tmux/scripts/resurrect-claude-resume.sh`) rewrites saved claude pane commands to `claude --resume <session-id>` using those tags
- `"~claude"` added to `@resurrect-processes` so restored panes re-run the full saved command

After a reboot, tmux-resurrect/continuum now reattaches every claude pane to its own conversation instead of starting fresh.

## Test plan
- [x] Hook tags pane on real claude startup (verified via `tmux show-options -p`)
- [x] Continuum autosave triggers hook chain; save file rewritten with `--resume <id>` (idempotent, `last` symlink intact, cleanup still keeps 30 files)
- [x] Panes launched with explicit `--resume` and non-claude panes untouched; whitelist is additive (nvim etc. still restored)
- [x] `claude --resume <old-id>` smoke test reopens a dead session's conversation
- [ ] Actual reboot restore (only verifiable on next reboot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)